### PR TITLE
iOS PhoneCallTask improved

### DIFF
--- a/Messaging/Lotz.Xam.Messaging.iOSUnified/PhoneCallTask.cs
+++ b/Messaging/Lotz.Xam.Messaging.iOSUnified/PhoneCallTask.cs
@@ -29,10 +29,15 @@ namespace Plugin.Messaging
 
             if (CanMakePhoneCall)
             {
-                var nsurl = new NSUrl("tel://" + number);
+                var nsurl = CreateNSUrl(number);
                 UIApplication.SharedApplication.OpenUrl(nsurl);                
             }
-        }        
+        }
+
+        private NSUrl CreateNSUrl(string number)
+        {
+            return new NSUrl(new Uri($"tel:{number}").AbsoluteUri);
+        }
 
         #endregion
     }

--- a/Messaging/Lotz.Xam.Messaging.iOSUnified/PhoneCallTask.cs
+++ b/Messaging/Lotz.Xam.Messaging.iOSUnified/PhoneCallTask.cs
@@ -19,7 +19,13 @@ namespace Plugin.Messaging
 
         public bool CanMakePhoneCall
         {
-            get { return true; }
+            get
+            {
+                // UIApplication.SharedApplication.CanOpenUrl does not validate the URL, it merely checks whether a handler for
+                // the URL has been installed on the system. Therefore string.Empty can be used as phone number.
+                var nsurl = CreateNSUrl(string.Empty);
+                return UIApplication.SharedApplication.CanOpenUrl(nsurl);
+            }
         }
 
         public void MakePhoneCall(string number, string name = null)


### PR DESCRIPTION
On iOS: Allow formatted telephone numbers & Added implementation for CanMakePhoneCall.

It would maybe be cleaner to have the actual number in CanMakePhoneCall. But this would break the Interface. And the underlying implementation of UIApplication.SharedApplication.CanOpenUrl doesn't check the phone number anyway.