### PR TITLE
Fixes #31 Check if a phone call is possible on Andriod

### DIFF
--- a/Messaging/Plugin.Messaging.Android/PhoneCallTask.cs
+++ b/Messaging/Plugin.Messaging.Android/PhoneCallTask.cs
@@ -15,7 +15,13 @@ namespace Plugin.Messaging
 
         public bool CanMakePhoneCall
         {
-            get { return true; }
+            get
+            {
+                var packageManager = Android.App.Application.Context.PackageManager;
+                var dialIntent = new Intent(Intent.ActionDial);
+
+                return null != dialIntent.ResolveActivity(packageManager);
+            }
         }
 
         public void MakePhoneCall(string number, string name = null)


### PR DESCRIPTION
This PR will check if a phone call is possible on Andriod. It was implemented similiar to the check if you can write an email.

This logic was tested successfully with our app on a PixelC, a Moto E 2Gen. and a Nexus 5X simulator.