### PR TITLE
Multiple SMS receipients

### DIFF
--- a/Messaging/Plugin.Messaging.iOSUnified/SmsTask.cs
+++ b/Messaging/Plugin.Messaging.iOSUnified/SmsTask.cs
@@ -33,7 +33,11 @@ namespace Plugin.Messaging
                 _smsController = new MFMessageComposeViewController();
 
                 if (!string.IsNullOrWhiteSpace(recipient))
-                    _smsController.Recipients = new[] { recipient };
+                { 
+                    string[] recipients = recipient.Split(';'); 
+                    if (recipients != null && recipients.Length > 0)  
+                        _smsController.Recipients = recipients;
+                }
                 
                 _smsController.Body = message;
 


### PR DESCRIPTION
Android and UWP can send multiple SMS using numbers separated by semi-colon, like "123456;996884;73839893"
With this update, even with iOS is it possible to use the same syntax in order to send SMS to multiple recipients.