### PR TITLE
Improve CanMakePhoneCall on iOS to check support of url and connection to a carrier

### DIFF
--- a/Messaging/Plugin.Messaging.iOSUnified/PhoneCallTask.cs
+++ b/Messaging/Plugin.Messaging.iOSUnified/PhoneCallTask.cs
@@ -2,9 +2,11 @@ using System;
 #if __UNIFIED__
 using Foundation;
 using UIKit;
+using CoreTelephony;
 #else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
+using MonoTouch.CoreTelephony;
 #endif
 
 namespace Plugin.Messaging
@@ -21,10 +23,19 @@ namespace Plugin.Messaging
         {
             get
             {
-                // UIApplication.SharedApplication.CanOpenUrl does not validate the URL, it merely checks whether a handler for
-                // the URL has been installed on the system. Therefore string.Empty can be used as phone number.
-                var nsurl = CreateNsUrl(string.Empty);
-                return UIApplication.SharedApplication.CanOpenUrl(nsurl);
+                var nsurl = CreateNsUrl("0000000000");
+                bool canCall = UIApplication.SharedApplication.CanOpenUrl(nsurl);
+
+                if (canCall)
+                {
+                    using (CTTelephonyNetworkInfo netInfo = new CTTelephonyNetworkInfo())
+                    {
+                        string mnc = netInfo.SubscriberCellularProvider?.MobileNetworkCode;
+
+                        return !string.IsNullOrEmpty(mnc) && mnc != "65535"; //65535 stands for NoNetwordProvider
+                    }
+                }
+                return false;
             }
         }
 


### PR DESCRIPTION
Improve detection of CanMakePhoneCall for iOS where iPad with version > iOS 8 was returning true.

This should fix #37 
